### PR TITLE
Fix errors in action

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,15 @@ if [ "$EVENT" = "assignment" ]; then
 fi
 
 
+if [ $NAME ]; then
+  gto show $NAME
+  gto history $NAME
+  export TYPE=`gto describe $NAME --type`
+  export ARTIFACT_PATH=`gto describe $NAME --path`
+  export DESCRIPTION=`gto describe $NAME --description`
+fi
+
+
 if [ "$2" = "true" ]; then
   gto show
 fi
@@ -34,19 +43,10 @@ if [ "$3" = "true" ]; then
 fi
 
 
-if [ $NAME ]; then
-  gto show $NAME
-  gto history $NAME
-  export TYPE=`gto describe $NAME --type`
-  export PATH=`gto describe $NAME --path`
-  export DESCRIPTION=`gto describe $NAME --description`
-fi
-
-
 echo "::set-output name=name::$NAME"
 echo "::set-output name=stage::$STAGE"
 echo "::set-output name=version::$VERSION"
 echo "::set-output name=event::$EVENT"
 echo "::set-output name=type::$TYPE"
-echo "::set-output name=path::$PATH"
+echo "::set-output name=path::$ARTIFACT_PATH"
 echo "::set-output name=description::$DESCRIPTION"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ git fetch --all --prune --tags
 git pull --all
 
 
+echo "\n\n\n============ GTO ============\n"
+echo "The Git tag that triggered this run: $GITHUB_REF"
+
+
 export NAME=`gto check-ref $GITHUB_REF --name`
 export VERSION=`gto check-ref $GITHUB_REF --version`
 export EVENT=`gto check-ref $GITHUB_REF --event`
@@ -20,21 +24,6 @@ if [ "$EVENT" = "assignment" ]; then
 fi
 
 
-export TYPE=`gto describe $NAME --type`
-export PATH=`gto describe $NAME --path`
-export DESCRIPTION=`gto describe $NAME --description`
-
-
-echo "\n\n\n============ GTO ============\n"
-echo "The Git tag that triggered this run: $GITHUB_REF"
-
-
-if [ $NAME ]; then
-  gto show $NAME
-  gto history $NAME
-fi
-
-
 if [ "$2" = "true" ]; then
   gto show
 fi
@@ -42,6 +31,15 @@ fi
 
 if [ "$3" = "true" ]; then
   gto history
+fi
+
+
+if [ $NAME ]; then
+  gto show $NAME
+  gto history $NAME
+  export TYPE=`gto describe $NAME --type`
+  export PATH=`gto describe $NAME --path`
+  export DESCRIPTION=`gto describe $NAME --description`
 fi
 
 


### PR DESCRIPTION
Due to some bash behavior unknown to me, after `gto describe $NAME --description` fails with exitcode 1, all other commands except for some simple ones aren't executed with `entrypoint.sh: line 28: printenv: command not found` (including `gto`, `printenv` and `which`).

I investigated this for a while, but could not find the source of this weird behavior. Overall, does `gto describe $NAME --something` have do fail with exitcode 1? Maybe it's correct to exit with 0, but don't print anything. The case I'm thinking about is when you don't have an annotation for this artifact at all, or you have the annotation, but no `description` in it.

UPD: found out the bug, it was stupid enough to not waste so much time on it. I was rewriting `PATH` variable one line above 🤦🏻‍♂️ 

